### PR TITLE
Add properties no nodes

### DIFF
--- a/ros2_knowledge_graph/include/ros2_knowledge_graph/Graph.hpp
+++ b/ros2_knowledge_graph/include/ros2_knowledge_graph/Graph.hpp
@@ -39,7 +39,7 @@ public:
   bool can_remove_node(const std::string node);
   bool remove_node(const std::string node);
   bool exist_node(const std::string node);
-  boost::optional<Node> get_node(const std::string node);
+  boost::optional<Node &> get_node(const std::string node);
 
   bool can_add_edge(const Edge & edge);
   bool add_edge(const Edge & edge);

--- a/ros2_knowledge_graph/include/ros2_knowledge_graph/GraphInterface.hpp
+++ b/ros2_knowledge_graph/include/ros2_knowledge_graph/GraphInterface.hpp
@@ -35,7 +35,7 @@ public:
   virtual bool add_node(const Node & node) = 0;
   virtual bool remove_node(const std::string node) = 0;
   virtual bool exist_node(const std::string node) = 0;
-  virtual boost::optional<Node> get_node(const std::string node) = 0;
+  virtual boost::optional<Node &> get_node(const std::string node) = 0;
 
   virtual bool add_edge(const Edge & edge) = 0;
   virtual bool remove_edge(const Edge & edge) = 0;

--- a/ros2_knowledge_graph/include/ros2_knowledge_graph/GraphNode.hpp
+++ b/ros2_knowledge_graph/include/ros2_knowledge_graph/GraphNode.hpp
@@ -52,7 +52,7 @@ public:
   bool add_node(const Node & node);
   bool remove_node(const std::string node);
   bool exist_node(const std::string node);
-  boost::optional<Node> get_node(const std::string node);
+  boost::optional<Node &> get_node(const std::string node);
 
   bool add_edge(const Edge & edge);
 

--- a/ros2_knowledge_graph/include/ros2_knowledge_graph/Types.hpp
+++ b/ros2_knowledge_graph/include/ros2_knowledge_graph/Types.hpp
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <string>
 #include <vector>
+#include <map>
 
 namespace ros2_knowledge_graph
 {
@@ -31,17 +32,30 @@ struct Node
   std::string name;
   std::string type;
 
+  std::map<std::string, std::string> properties {};
+
   std::string to_string() const
   {
-    return "node::" + name + "::" + type;
+    std::string ret;
+    ret = "node::" + name + "::" + type;
+
+    for (const auto & property : properties) {
+      ret = ret + "::" + property.first + ":" + property.second;
+    }
+
+    return ret;
   }
 
   void from_string(const std::string & node_str)
   {
     auto tokens = tokenize(node_str, "::");
-    assert(tokens.size() == 3);
     name = tokens[1];
     type = tokens[2];
+
+    for (int i = 3; i < tokens.size(); i++) {
+      auto prop_token = tokenize(tokens[i], ":");
+      properties[prop_token[0]] = prop_token[1];
+    }
   }
 };
 

--- a/ros2_knowledge_graph/src/ros2_knowledge_graph/Graph.cpp
+++ b/ros2_knowledge_graph/src/ros2_knowledge_graph/Graph.cpp
@@ -89,7 +89,7 @@ Graph::exist_node(const std::string node)
   return nodes_.find(node) != nodes_.end();
 }
 
-boost::optional<Node>
+boost::optional<Node &>
 Graph::get_node(const std::string node)
 {
   if (exist_node(node)) {

--- a/ros2_knowledge_graph/src/ros2_knowledge_graph/GraphNode.cpp
+++ b/ros2_knowledge_graph/src/ros2_knowledge_graph/GraphNode.cpp
@@ -306,7 +306,7 @@ GraphNode::exist_node(const std::string node)
   return graph_.exist_node(node);
 }
 
-boost::optional<Node>
+boost::optional<Node &>
 GraphNode::get_node(const std::string node)
 {
   std::lock_guard<std::mutex> lock(mutex_);
@@ -314,11 +314,10 @@ GraphNode::get_node(const std::string node)
   auto opt_node = graph_.get_node(node);
 
   if (opt_node.has_value()) {
-    Node modificable_node = opt_node.value();
     for (const auto & layer_id : layer_ids_) {
-      layers_[layer_id]->on_get_node(modificable_node);
+      layers_[layer_id]->on_get_node(opt_node.value());
     }
-    return modificable_node;
+    return opt_node;
   } else {
     return {};
   }

--- a/ros2_knowledge_graph/test/ros2_knowledge_graph_node_test.cpp
+++ b/ros2_knowledge_graph/test/ros2_knowledge_graph_node_test.cpp
@@ -98,7 +98,10 @@ TEST(ros2_knowledge_graphnode, graph_twin)
   graph.start();
   graph2.start();
 
-  graph.add_node(ros2_knowledge_graph::Node{"paco", "person"});
+  graph.add_node(
+    ros2_knowledge_graph::Node{"paco", "person", {{"mobile", "555-456"}, {"age", "42"}}});
+
+  graph.get_node("paco").value().properties["gender"] = "male";
 
   auto test_node = rclcpp::Node::make_shared("test_node");
   auto start = test_node->now();
@@ -106,6 +109,9 @@ TEST(ros2_knowledge_graphnode, graph_twin)
 
   ASSERT_TRUE(graph.exist_node("paco"));
   ASSERT_TRUE(graph2.exist_node("paco"));
+
+  ASSERT_EQ(graph2.get_node("paco").value().properties["age"], "42");
+  ASSERT_EQ(graph2.get_node("paco").value().properties["gender"], "male");
 
   graph.remove_node("paco");
   start = test_node->now();

--- a/ros2_knowledge_graph/test/ros2_knowledge_graph_test.cpp
+++ b/ros2_knowledge_graph/test/ros2_knowledge_graph_test.cpp
@@ -17,6 +17,7 @@
 #include <regex>
 #include <iostream>
 #include <memory>
+#include <map>
 
 #include "ros2_knowledge_graph/Graph.hpp"
 #include "ros2_knowledge_graph/Types.hpp"
@@ -75,6 +76,85 @@ TEST(ros2_knowledge_graph, graph_operations)
   ASSERT_EQ(graph.get_edges_from_node_by_data("kitchen", "is[[:alnum:]_]*").size(), 3);
   ASSERT_EQ(graph.get_edges_from_node_by_data("kitchen", "is[[:alnum:]_]*", "symbolic").size(), 2);
   ASSERT_EQ(graph.get_edges_by_data("is[[:alnum:]_]*").size(), 4);
+
+  ASSERT_EQ(graph.get_num_edges(), 6);
+  graph.remove_node("r2d2");
+  ASSERT_EQ(graph.get_num_edges(), 0);
+
+
+  std::string graph_str = graph.to_string();
+  ros2_knowledge_graph::Graph graph2;
+  graph2.from_string(graph_str);
+  std::string graph2_str = graph2.to_string();
+
+  ASSERT_EQ(graph_str, graph2_str);
+}
+
+
+TEST(ros2_knowledge_graph, graph_operations_with_props)
+{
+  ros2_knowledge_graph::Graph graph;
+
+  graph.add_node(
+    ros2_knowledge_graph::Node{"paco", "person", {{"mobile", "555-456"}, {"age", "42"}}});
+  ASSERT_TRUE(graph.exist_node("paco"));
+  ASSERT_EQ(graph.get_node("paco").value().properties["age"], "42");
+
+  graph.get_node("paco").value().properties["gender"] = "male";
+  ASSERT_EQ(graph.get_node("paco").value().properties["gender"], "male");
+
+  graph.remove_node("paco");
+  ASSERT_FALSE(graph.exist_node("paco"));
+  ASSERT_EQ(graph.get_num_nodes(), 0);
+
+
+  ASSERT_FALSE(graph.exist_node("r2d2"));
+  graph.add_node(ros2_knowledge_graph::Node{"r2d2", "robot"});
+  ASSERT_TRUE(graph.exist_node("r2d2"));
+  ASSERT_FALSE(graph.exist_node("kitchen"));
+  graph.add_node(ros2_knowledge_graph::Node{"kitchen", "room"});
+  ASSERT_TRUE(graph.exist_node("kitchen"));
+
+  graph.add_node(ros2_knowledge_graph::Node{"room1", "room"});
+  graph.add_node(ros2_knowledge_graph::Node{"room2", "room"});
+
+  graph.remove_node("r2d2");
+  ASSERT_FALSE(graph.exist_node("r2d2"));
+  graph.add_node(ros2_knowledge_graph::Node{"r2d2", "robot"});
+  ASSERT_TRUE(graph.exist_node("r2d2"));
+
+  graph.get_node("r2d2").value().properties["id"] = "1234";
+
+  ASSERT_TRUE(graph.add_edge(ros2_knowledge_graph::Edge{"is", "symbolic", "r2d2", "kitchen"}));
+  ASSERT_TRUE(graph.exist_edge(ros2_knowledge_graph::Edge{"is", "symbolic", "r2d2", "kitchen"}));
+  ASSERT_TRUE(graph.remove_edge(ros2_knowledge_graph::Edge{"is", "symbolic", "r2d2", "kitchen"}));
+  ASSERT_FALSE(graph.exist_edge(ros2_knowledge_graph::Edge{"is", "symbolic", "r2d2", "kitchen"}));
+  ASSERT_TRUE(graph.add_edge(ros2_knowledge_graph::Edge{"is", "symbolic", "r2d2", "kitchen"}));
+  ASSERT_TRUE(graph.add_edge(ros2_knowledge_graph::Edge{"is_near", "symbolic", "kitchen", "r2d2"}));
+  ASSERT_TRUE(
+    graph.add_edge(
+      ros2_knowledge_graph::Edge{
+    "is_verynear", "symbolic", "kitchen", "r2d2"}));
+  ASSERT_TRUE(
+    graph.add_edge(
+      ros2_knowledge_graph::Edge{
+    "is_verynear_very", "sympedal", "kitchen", "r2d2"}));
+  ASSERT_TRUE(graph.add_edge(ros2_knowledge_graph::Edge{"related", "symbolic", "kitchen", "r2d2"}));
+  ASSERT_TRUE(graph.add_edge(ros2_knowledge_graph::Edge{"related", "metric", "kitchen", "r2d2"}));
+
+  ASSERT_EQ(graph.get_node_names_by_id("room[[:alnum:]_]*").size(), 2);
+  ASSERT_EQ(graph.get_node_names_by_id("kitchen").size(), 1);
+  ASSERT_EQ(graph.get_node_names_by_type("room").size(), 3);
+  ASSERT_EQ(graph.get_node_names_by_type("robot").size(), 1);
+  ASSERT_EQ(graph.get_edges_from_node("kitchen").size(), 5);
+  ASSERT_EQ(graph.get_edges_from_node("kitchen", "symbolic").size(), 3);
+  ASSERT_EQ(graph.get_edges_from_node_by_data("kitchen", "is[[:alnum:]_]*").size(), 3);
+  ASSERT_EQ(graph.get_edges_from_node_by_data("kitchen", "is[[:alnum:]_]*", "symbolic").size(), 2);
+  ASSERT_EQ(graph.get_edges_by_data("is[[:alnum:]_]*").size(), 4);
+
+  std::map<std::string, std::string>::const_iterator node_r2d2_it =
+    graph.get_nodes().find("r2d2")->second.properties.find("id");
+  ASSERT_EQ(node_r2d2_it->second, "1234");
 
   ASSERT_EQ(graph.get_num_edges(), 6);
   graph.remove_node("r2d2");


### PR DESCRIPTION
Hi,

This PR adds a `properties` field to `Node`. This is a `std::map<std::string, std::string>`. Now you can do things like:

```
graph.add_node(
    ros2_knowledge_graph::Node{"paco", "person", {{"mobile", "555-456"}, {"age", "42"}}});
graph.get_node("paco").value().properties["gender"] = "male";

std::map<std::string, std::string>::const_iterator node_paco_it =
    graph.get_nodes().find("paco")->second.properties.find("gender")
```

I hope it helps!!

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>