### PR TITLE
Added method get_edges_from_node_by_data

### DIFF
--- a/ros2_knowledge_graph/include/ros2_knowledge_graph/GraphNode.hpp
+++ b/ros2_knowledge_graph/include/ros2_knowledge_graph/GraphNode.hpp
@@ -55,6 +55,9 @@ public:
     return {};
   }
 
+  std::vector<ros2_knowledge_graph_msgs::msg::Edge> get_edges_from_node_by_data( 
+    const std::string &source, const std::string &expr);
+
   const std::vector<ros2_knowledge_graph_msgs::msg::Node> & get_nodes() {return graph_->nodes;}
   const std::vector<ros2_knowledge_graph_msgs::msg::Edge> & get_edges()
   {

--- a/ros2_knowledge_graph/src/ros2_knowledge_graph/GraphNode.cpp
+++ b/ros2_knowledge_graph/src/ros2_knowledge_graph/GraphNode.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <regex>
 
 #include "ros2_knowledge_graph_msgs/msg/graph.hpp"
 #include "ros2_knowledge_graph_msgs/msg/node.hpp"
@@ -447,6 +448,25 @@ GraphNode::update_tf_edge(ros2_knowledge_graph_msgs::msg::Edge & edge)
       edge.source_node_id, edge.target_node_id, tf2::TimePointZero);
   } catch (tf2::LookupException e) {
   }
+}
+
+std::vector<ros2_knowledge_graph_msgs::msg::Edge>
+GraphNode::get_edges_from_node_by_data(
+  const std::string & source, const std::string & expr)
+{
+  std::vector<ros2_knowledge_graph_msgs::msg::Edge> ret;
+
+  for (auto & edge : graph_->edges) {
+    if ( (edge.source_node_id == source) &&
+      (edge.content.type == ros2_knowledge_graph_msgs::msg::Content::STRING) )
+    {
+      if (std::regex_match(edge.content.string_value, std::regex(expr)))
+        {
+          ret.push_back(edge);
+        }
+    }
+  }
+  return ret;
 }
 
 }  // namespace ros2_knowledge_graph

--- a/ros2_knowledge_graph/test/ros2_knowledge_graph_node_test.cpp
+++ b/ros2_knowledge_graph/test/ros2_knowledge_graph_node_test.cpp
@@ -131,6 +131,11 @@ TEST(ros2_knowledge_graphnode, graph_operations)
   auto edge_2_ret_1 = graph_node.get_edges<std::string>("r2d2", "paco");
   ASSERT_EQ(edge_2_ret_1.size(), 2u);
 
+  auto edges_by_data_ret1 = graph_node.get_edges_from_node_by_data("r2d2", "s$");
+  ASSERT_EQ(edges_by_data_ret1.size(), 2u);
+
+  auto edges_by_data_ret2 = graph_node.get_edges_from_node_by_data("r2d2", "^sees");
+  ASSERT_EQ(edges_by_data_ret2.size(), 1u);
 
   auto content_edge_1_ret_2 =
     ros2_knowledge_graph::get_content<std::string>(edge_2_ret_1[0].content);


### PR DESCRIPTION
This is "almost" like the origintal method. Differences:
- We are forcing edge content to be type string. Otherwise we won't know how to perform the regex
- We don't return "Edge" objects but msg objects. Method "get_edges" works this way and this is a sort of special case.

A simple test case is added, but I'm not 100% sure about i.